### PR TITLE
Use user name in subject CN in client cert generation

### DIFF
--- a/common/cert.go
+++ b/common/cert.go
@@ -26,7 +26,7 @@ func GenerateClientCert(userName string, daysValid int) (_ []byte, err error) {
 	newCert := x509.Certificate{
 		Subject: pkix.Name{
 			Organization: []string{"DB Browser for SQLite"},
-			CommonName:   DB4SServer(),
+			CommonName:   emailAddress,
 			ExtraNames:   []pkix.AttributeTypeAndValue{{Type: oidEmailAddress, Value: emailAddress}},
 		},
 		BasicConstraintsValid: true,


### PR DESCRIPTION
The subject CN (as opposed to the issuer CN) is more of a certificate
owner. In the case of client certs this is probably the user name (or
the user name plus something). So this should be more correct. It also
allows the user to distinguish between multiple client certs for the
same host.

What do you think, @justinclift? Is this safe to just merge? Or is this field already in use somewhere else?