### PR TITLE
Add extra validation of user supplied api keys

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -155,8 +155,15 @@ func checkAuth(w http.ResponseWriter, r *http.Request) (loggedInUser string, err
 	// Extract the API key from the request
 	apiKey := r.FormValue("apikey")
 
-	// Check if API key was provided
+	// Check if an API key was provided
 	if apiKey != "" {
+		// Validate the API key
+		err = com.CheckAPIKey(apiKey)
+		if err != nil {
+			err = fmt.Errorf("Incorrect or unknown API key and certificate")
+			return
+		}
+
 		// Look up the owner of the API key
 		loggedInUser, err = com.GetAPIKeyUser(apiKey)
 	} else {

--- a/common/userinput.go
+++ b/common/userinput.go
@@ -11,7 +11,16 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/segmentio/ksuid"
 )
+
+// CheckAPIKey checks if a given string is a valid API key
+func CheckAPIKey(apiKey string) (err error) {
+	// Validate the API key
+	_, err = ksuid.Parse(apiKey)
+	return
+}
 
 // CheckUnicode checks if a given string is unicode, and safe for using in SQLite queries (eg no SQLite control characters)
 func CheckUnicode(rawInput string) (str string, err error) {


### PR DESCRIPTION
Noticed a few days ago that we don't do any explicit validation of API keys, though we kind of do as a side effect (check if they're assigned to an owner).

So, this just adds basic functionality for validating them, and hooks up it up in an obvious place. :smile: