### PR TITLE
Add permissions for API keys

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -155,8 +155,15 @@ func checkAuth(w http.ResponseWriter, r *http.Request) (loggedInUser string, err
 	// Extract the API key from the request
 	apiKey := r.FormValue("apikey")
 
-	// Check if API key was provided
+	// Check if an API key was provided
 	if apiKey != "" {
+		// Validate the API key
+		err = com.CheckAPIKey(apiKey)
+		if err != nil {
+			err = fmt.Errorf("Incorrect or unknown API key and certificate")
+			return
+		}
+
 		// Look up the owner of the API key
 		loggedInUser, err = com.GetAPIKeyUser(apiKey)
 	} else {

--- a/common/postgresql.go
+++ b/common/postgresql.go
@@ -131,6 +131,15 @@ func APIKeySave(key, loggedInUser string, dateCreated time.Time) error {
 	return nil
 }
 
+// APIPermStore saves a new API key to the PostgreSQL database
+func APIPermStore(loggedInUser, apiKey string, dbName string, perm APIPermission, value bool) error {
+
+	// TODO: Everything for this function ;)
+	fmt.Printf("User: %v, api key: %v, database: %v, perm: %v, value: %v\n", loggedInUser, apiKey, dbName, perm, value)
+
+	return nil
+}
+
 // CheckDBExists checks if a database exists. It does NOT perform any permission checks.
 // If an error occurred, the true/false value should be ignored, as only the error value is valid
 func CheckDBExists(dbOwner, dbFolder, dbName string) (bool, error) {

--- a/common/types.go
+++ b/common/types.go
@@ -241,6 +241,27 @@ type APIKey struct {
 	DateCreated time.Time `json:"date_created"`
 }
 
+type APIPermission uint
+
+const (
+	APIPERM_BRANCHES  = 0 // These are not iota, as it would be seriously bad for these numbers to change
+	APIPERM_COLUMNS   = 1
+	APIPERM_COMMITS   = 2
+	APIPERM_DATABASES = 3
+	APIPERM_DELETE    = 4
+	APIPERM_DIFF      = 5
+	APIPERM_DOWNLOAD  = 6
+	APIPERM_INDEXES   = 7
+	APIPERM_METADATA  = 8
+	APIPERM_QUERY     = 9
+	APIPERM_RELEASES  = 10
+	APIPERM_TABLES    = 11
+	APIPERM_TAGS      = 12
+	APIPERM_UPLOAD    = 13
+	APIPERM_VIEWS     = 14
+	APIPERM_WEBPAGE   = 15
+)
+
 type Auth0Set struct {
 	CallbackURL string
 	ClientID    string

--- a/common/userinput.go
+++ b/common/userinput.go
@@ -11,7 +11,16 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/segmentio/ksuid"
 )
+
+// CheckAPIKey checks if a given string is a valid API key
+func CheckAPIKey(apiKey string) (err error) {
+	// Validate the API key
+	_, err = ksuid.Parse(apiKey)
+	return
+}
 
 // CheckUnicode checks if a given string is unicode, and safe for using in SQLite queries (eg no SQLite control characters)
 func CheckUnicode(rawInput string) (str string, err error) {

--- a/database/api_permissions.sql
+++ b/database/api_permissions.sql
@@ -1,0 +1,47 @@
+
+-- *** api_keys tables needed a unique key added to the key_id column ***
+
+--
+-- Name: api_keys api_keys_key_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_keys
+    ADD CONSTRAINT api_keys_key_id UNIQUE (key_id);
+
+-- *** Hang on, this ^^^ seems like it's just a constraint, but no index?  Look into it when less sleepy. ;)
+
+    
+-- *** New table for holding API key permissions ***
+
+--
+-- Name: api_permissions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.api_permissions (
+    key_id bigint,
+    user_id bigint,
+    db_id bigint,
+    permissions jsonb
+);
+
+--
+-- Name: api_permissions api_permissions_api_keys_key_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_permissions
+    ADD CONSTRAINT api_permissions_api_keys_key_id_fk FOREIGN KEY (key_id) REFERENCES public.api_keys(key_id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+--
+-- Name: api_permissions api_permissions_sqlite_databases_db_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_permissions
+    ADD CONSTRAINT api_permissions_sqlite_databases_db_id_fk FOREIGN KEY (db_id) REFERENCES public.sqlite_databases(db_id) ON UPDATE CASCADE ON DELETE CASCADE;
+
+--
+-- Name: api_permissions api_permissions_users_user_id_fk; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.api_permissions
+    ADD CONSTRAINT api_permissions_users_user_id_fk FOREIGN KEY (user_id) REFERENCES public.users(user_id) ON UPDATE CASCADE ON DELETE CASCADE;
+ 

--- a/webui/main.go
+++ b/webui/main.go
@@ -157,7 +157,7 @@ func apiPermissionsUpdateHandler(w http.ResponseWriter, r *http.Request) {
 
 
 	// TODO: Store the updated value in the database
-	err = com.APIPermStore(loggedInUser, apiKey, "mydatabase", perm, value)
+	err = com.APIPermStore(loggedInUser, apiKey, "tempdb1.sqlite", perm, value)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/webui/main.go
+++ b/webui/main.go
@@ -82,6 +82,10 @@ func apiPermissionsUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO: Retrieve the database name
+
+	// TODO: Add the "All databases" value to the front end and here
+
 	// Retrieve permission name
 	p := r.PostFormValue("perm")
 	p2, err := url.QueryUnescape(p)
@@ -139,7 +143,7 @@ func apiPermissionsUpdateHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate the provided value
+	// Validate the provided permission value
 	value := false
 	switch strings.ToLower(v2) {
 	case "true":
@@ -155,9 +159,8 @@ func apiPermissionsUpdateHandler(w http.ResponseWriter, r *http.Request) {
 
 	// TODO: Make sure the given API key has been issued to this user
 
-
-	// TODO: Store the updated value in the database
-	err = com.APIPermStore(loggedInUser, apiKey, "tempdb1.sqlite", perm, value)
+	// Store the updated permissions in the database
+	err = com.APIPermStore(loggedInUser, apiKey, "tempdb1.sqlite", true, perm, value)
 	if err != nil {
 		log.Println(err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/webui/pages.go
+++ b/webui/pages.go
@@ -1894,6 +1894,7 @@ func prefPage(w http.ResponseWriter, r *http.Request, loggedInUser string) {
 	var pageData struct {
 		APIKeys     []com.APIKey
 		Auth0       com.Auth0Set
+		DBNames     []string
 		DisplayName string
 		Email       string
 		MaxRows     int
@@ -1934,6 +1935,9 @@ func prefPage(w http.ResponseWriter, r *http.Request, loggedInUser string) {
 		errorPage(w, r, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// TODO: Retrieve the list of user databases
+	pageData.DBNames = []string{"foo", "bar", "tempdb1.sqlite"}
 
 	// Add Auth0 info to the page data
 	pageData.Auth0 = collectPageAuth0Info()

--- a/webui/pages.go
+++ b/webui/pages.go
@@ -1936,8 +1936,15 @@ func prefPage(w http.ResponseWriter, r *http.Request, loggedInUser string) {
 		return
 	}
 
-	// TODO: Retrieve the list of user databases
-	pageData.DBNames = []string{"foo", "bar", "tempdb1.sqlite"}
+	// Create the list of databases belonging to the user
+	dbList, err := com.UserDBs(loggedInUser, com.DB_BOTH)
+	if err != nil {
+		errorPage(w, r, http.StatusInternalServerError, "Retrieving list of databases failed")
+		return
+	}
+	for _, db := range dbList {
+		pageData.DBNames = append(pageData.DBNames, db.Database)
+	}
 
 	// Add Auth0 info to the page data
 	pageData.Auth0 = collectPageAuth0Info()

--- a/webui/templates/preferences.html
+++ b/webui/templates/preferences.html
@@ -77,15 +77,15 @@
                                 <th>Branches()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="branchesClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="branchesClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="apiPermUpdate(row.key, 'branches', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="apiPermUpdate(row.key, 'branches', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Metadata()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="metadataClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="metadataClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="apiPermUpdate(row.key, 'metadata', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="apiPermUpdate(row.key, 'metadata', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -93,15 +93,15 @@
                                 <th>Columns()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="columnsClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="columnsClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="apiPermUpdate(row.key, 'columns', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="apiPermUpdate(row.key, 'columns', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Query()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="queryClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="queryClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="apiPermUpdate(row.key, 'query', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="apiPermUpdate(row.key, 'query', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -109,15 +109,15 @@
                                 <th>Commits()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="commitsClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="commitsClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="apiPermUpdate(row.key, 'commits', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="apiPermUpdate(row.key, 'commits', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Releases()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="releasesClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="releasesClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="apiPermUpdate(row.key, 'releases', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="apiPermUpdate(row.key, 'releases', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -125,15 +125,15 @@
                                 <th>Databases()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="databasesClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="databasesClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="apiPermUpdate(row.key, 'databases', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="apiPermUpdate(row.key, 'databases', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Tables()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioTables" ng-click="tablesClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioTables" ng-click="tablesClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioTables" ng-click="apiPermUpdate(row.key, 'tables', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioTables" ng-click="apiPermUpdate(row.key, 'tables', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -141,15 +141,15 @@
                                 <th>Delete()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="deleteClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="deleteClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="apiPermUpdate(row.key, 'delete', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="apiPermUpdate(row.key, 'delete', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Tags()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioTags" ng-click="tagsClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioTags" ng-click="tagsClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioTags" ng-click="apiPermUpdate(row.key, 'tags', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioTags" ng-click="apiPermUpdate(row.key, 'tags', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -157,15 +157,15 @@
                                 <th>Diff()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="diffClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="diffClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="apiPermUpdate(row.key, 'diff', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="apiPermUpdate(row.key, 'diff', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Upload()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="uploadClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="uploadClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="apiPermUpdate(row.key, 'upload', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="apiPermUpdate(row.key, 'upload', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -173,15 +173,15 @@
                                 <th>Download()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="downloadClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="downloadClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="apiPermUpdate(row.key, 'download', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="apiPermUpdate(row.key, 'download', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Views()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioViews" ng-click="viewsClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioViews" ng-click="viewsClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioViews" ng-click="apiPermUpdate(row.key, 'views', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioViews" ng-click="apiPermUpdate(row.key, 'views', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -189,15 +189,15 @@
                                 <th>Indexes()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="indexesClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="indexesClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="apiPermUpdate(row.key, 'indexes', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="apiPermUpdate(row.key, 'indexes', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Webpage()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="webpageClick('true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="webpageClick('false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="apiPermUpdate(row.key, 'webpage', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="apiPermUpdate(row.key, 'webpage', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -284,6 +284,34 @@
 
         $scope.showLock = function() {
             lock.show();
+        };
+
+        // Call the server to update the api permission
+        $scope.apiPermUpdate = function(apikey, perm, value) {
+            console.log("apikey: " + apikey);
+            console.log("perm: " + perm);
+            console.log("value: " + value);
+
+            $http({
+                method: "POST",
+                url: "/x/apipermupdate/",
+                data: $httpParamSerializerJQLike({
+                    "apikey": encodeURIComponent(apikey),
+                    "perm": encodeURIComponent(perm),
+                    "value": encodeURIComponent(value)
+                }),
+                headers: { "Content-Type": "application/x-www-form-urlencoded" }
+            }).then(function (response) {
+                console.log(response.data);
+
+                $scope.statusMessageColour = "green";
+                $scope.statusMessage = "Server message: " + response.data;
+            }, function failure(response) {
+                console.log(response.data);
+
+                $scope.statusMessageColour = "red";
+                $scope.statusMessage = "Server message: " + response.data;
+            });
         };
 
         // Generate a new API key

--- a/webui/templates/preferences.html
+++ b/webui/templates/preferences.html
@@ -69,7 +69,7 @@
                                     <a href="">All databases</a>
                                 </li>
                                 <li class="divider"></li>
-                                <li ng-repeat="database in dbList" role="menuitem" ng-click="selectDB(api.key, database)">
+                                <li ng-repeat="database in dbList | orderBy" role="menuitem" ng-click="selectDB(api.key, database)">
                                     <a href="">{{ database }}</a>
                                 </li>
                             </ul>
@@ -243,7 +243,7 @@
         $scope.dbList = [[ .DBNames ]];
 
         // Set initial permissions to true for the API keys
-        // TODO: These will need updating, depending on what the server sends
+        // TODO: These will need updating, depending on what the server sets
         $scope.radioBranches = "true";
         $scope.radioColumns = "true";
         $scope.radioCommits = "true";
@@ -261,13 +261,12 @@
         $scope.radioViews = "true";
         $scope.radioWebpage = "true";
 
-        // TODO: These will depend on what the server sends. eg existing value stored in the backend
+        // TODO: Update this to use what the server sets. eg existing value stored in the backend
         $scope.allDatabases = true;
         $scope.selectedDB = "All databases";
 
         // Send the changed database selection to the server
         $scope.changeDB = function(apiKey, newDB) {
-console.log("changeDB() called");
             // Send the new database info to the server
             $http({
                 method: "POST",
@@ -279,12 +278,10 @@ console.log("changeDB() called");
                 }),
                 headers: { "Content-Type": "application/x-www-form-urlencoded" }
             }).then(function (response) {
-console.log(response.data);
                 // Clear any error message
                 $scope.statusMessageColour = "green";
                 $scope.statusMessage = "";
             }, function failure(response) {
-console.log(response.data);
                 $scope.statusMessageColour = "red";
                 $scope.statusMessage = "Server message: " + response.data;
             });
@@ -294,7 +291,6 @@ console.log(response.data);
         $scope.allDBs = function(apiKey) {
             $scope.selectedDB = "All databases";
             $scope.allDatabases = true;
-console.log("ALL databases set to true");
 
             // Send the change to the backend
             $scope.changeDB(apiKey, "");
@@ -304,9 +300,7 @@ console.log("ALL databases set to true");
         $scope.selectDB = function(apiKey, newDB) {
             // TODO: Work with multiple api keys
             $scope.selectedDB = newDB;
-console.log("Selected database set to: " + newDB);
             $scope.allDatabases = false;
-console.log("ALL databases set to false");
 
             // Send the change to the backend
             $scope.changeDB(apiKey, newDB);

--- a/webui/templates/preferences.html
+++ b/webui/templates/preferences.html
@@ -6,10 +6,10 @@
 [[ template "header" . ]]
 <div style="margin-left: 2%; margin-right: 2%; padding-left: 2%; padding-right: 2%;">
     <div class="row">
-        <div class="col-md-3">
+        <div class="col-md-1">
             &nbsp;
         </div>
-        <div class="col-md-6">
+        <div class="col-md-10">
             <h2 style="text-align: center;">Settings</h2>
             <h3 style="text-align: center;">Used when uploading databases</h3>
             <form action="/pref" method="post">
@@ -47,16 +47,168 @@
                 <tr>
                     <th>Key</th>
                     <th>Generation date</th>
+                    <th>Databases</th>
+                    <th>Allowed function calls</th>
                 </tr>
                 <tr ng-repeat="row in apiKeys">
-                    <td>{{ row.key }}</td>
+                    <td><p style="font-family: monospace, monospace; text-align: center;">{{ row.key }}</p>
+                        <div style="text-align: center;">
+                            <input type="submit" class="btn btn-primary" value="Revoke" ng-click="apiKeyRevoke()">
+                        </div>
+                    </td>
                     <td>{{ row.date_created | date : 'medium' }}</td>
+                    <td>
+                        <div class="btn-group" uib-dropdown keyboard-nav="true">
+                            <button id="viewtable" type="button" class="btn">{{ selectedDB }}</button>
+
+                            <button type="button" uib-dropdown-toggle class="btn btn-default">
+                                <span class="caret"></span>
+                            </button>
+                            <ul uib-dropdown-menu class="dropdown-menu" role="menu">
+                                <li ng-repeat="database in dbList" role="menuitem" ng-click="changeDB(database)">
+                                    <a href="">{{ database }}</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </td>
+                    <td>
+                        <table class="table table-striped table-responsive settingsTable">
+                            <tr>
+                                <th>Branches()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="branchesClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="branchesClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Metadata()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="metadataClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="metadataClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Columns()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="columnsClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="columnsClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Query()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="queryClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="queryClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Commits()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="commitsClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="commitsClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Releases()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="releasesClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="releasesClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Databases()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="databasesClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="databasesClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Tables()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioTables" ng-click="tablesClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioTables" ng-click="tablesClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Delete()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="deleteClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="deleteClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Tags()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioTags" ng-click="tagsClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioTags" ng-click="tagsClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Diff()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="diffClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="diffClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Upload()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="uploadClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="uploadClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Download()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="downloadClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="downloadClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Views()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioViews" ng-click="viewsClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioViews" ng-click="viewsClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th>Indexes()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="indexesClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="indexesClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                                <th>Webpage()</th>
+                                <td>
+                                    <div class="btn-group">
+                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="webpageClick('true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="webpageClick('false')" uib-btn-radio="'false'">No</label>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
                 </tr>
                 <tr ng-if="apiKeys === null">
-                    <td colspan="2" style="text-align: center;">You don't have any API keys yet</td>
+                    <td colspan="3" style="text-align: center;">You don't have any API keys yet</td>
                 </tr>
                 <tr>
-                    <td style="border-left: none;" colspan="2">
+                    <td style="border-left: none;" colspan="4">
                         <div>
                             <div class="row" ng-if="statusMessage != ''">
                                 <div style="text-align: center; padding-bottom: 8px;">
@@ -71,7 +223,7 @@
                 </tr>
             </table>
         </div>
-        <div class="col-md-3">
+        <div class="col-md-1">
             &nbsp;
         </div>
     </div>
@@ -82,6 +234,30 @@
     app.controller('prefView', function($scope, $http, $httpParamSerializerJQLike) {
         // API Keys
         $scope.apiKeys = [[ .APIKeys ]];
+
+        // Set initial permissions to true for the API keys
+        $scope.radioBranches = "true";
+        $scope.radioColumns = "true";
+        $scope.radioCommits = "true";
+        $scope.radioDatabases = "true";
+        $scope.radioDelete = "true";
+        $scope.radioDiff = "true";
+        $scope.radioDownload = "true";
+        $scope.radioIndexes = "true";
+        $scope.radioMetadata = "true";
+        $scope.radioQuery = "true";
+        $scope.radioReleases = "true";
+        $scope.radioTables = "true";
+        $scope.radioTags = "true";
+        $scope.radioUpload = "true";
+        $scope.radioViews = "true";
+        $scope.radioWebpage = "true";
+
+        // Placeholder values
+        // TODO: ...
+        $scope.dbList = ["SomeDatabase", "AnotherDatabase", "MyDatabase"];
+        $scope.selectedDB = "MyDatabase";
+
 
         // If the supplied display name is blank, we set a placeholder value instead
         $scope.FullName = "";

--- a/webui/templates/preferences.html
+++ b/webui/templates/preferences.html
@@ -50,13 +50,13 @@
                     <th>Databases</th>
                     <th>Allowed function calls</th>
                 </tr>
-                <tr ng-repeat="row in apiKeys">
-                    <td><p style="font-family: monospace, monospace; text-align: center;">{{ row.key }}</p>
+                <tr ng-repeat="api in apiKeys">
+                    <td><p style="font-family: monospace, monospace; text-align: center;">{{ api.key }}</p>
                         <div style="text-align: center;">
-                            <input type="submit" class="btn btn-primary" value="Revoke" ng-click="apiKeyRevoke()">
+                            <input type="submit" class="btn btn-primary" value="Revoke" ng-click="apiKeyRevoke(api.key)">
                         </div>
                     </td>
-                    <td>{{ row.date_created | date : 'medium' }}</td>
+                    <td>{{ api.date_created | date : 'medium' }}</td>
                     <td>
                         <div class="btn-group" uib-dropdown keyboard-nav="true">
                             <button id="viewtable" type="button" class="btn">{{ selectedDB }}</button>
@@ -65,7 +65,11 @@
                                 <span class="caret"></span>
                             </button>
                             <ul uib-dropdown-menu class="dropdown-menu" role="menu">
-                                <li ng-repeat="database in dbList" role="menuitem" ng-click="changeDB(database)">
+                                <li role="menuitem" ng-click="allDBs(api.key)">
+                                    <a href="">All databases</a>
+                                </li>
+                                <li class="divider"></li>
+                                <li ng-repeat="database in dbList" role="menuitem" ng-click="selectDB(api.key, database)">
                                     <a href="">{{ database }}</a>
                                 </li>
                             </ul>
@@ -77,15 +81,15 @@
                                 <th>Branches()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="apiPermUpdate(row.key, 'branches', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="apiPermUpdate(row.key, 'branches', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="apiPermUpdate(api.key, 'branches', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioBranches" ng-click="apiPermUpdate(api.key, 'branches', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Metadata()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="apiPermUpdate(row.key, 'metadata', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="apiPermUpdate(row.key, 'metadata', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="apiPermUpdate(api.key, 'metadata', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioMetadata" ng-click="apiPermUpdate(api.key, 'metadata', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -93,15 +97,15 @@
                                 <th>Columns()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="apiPermUpdate(row.key, 'columns', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="apiPermUpdate(row.key, 'columns', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="apiPermUpdate(api.key, 'columns', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioColumns" ng-click="apiPermUpdate(api.key, 'columns', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Query()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="apiPermUpdate(row.key, 'query', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="apiPermUpdate(row.key, 'query', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="apiPermUpdate(api.key, 'query', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioQuery" ng-click="apiPermUpdate(api.key, 'query', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -109,15 +113,15 @@
                                 <th>Commits()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="apiPermUpdate(row.key, 'commits', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="apiPermUpdate(row.key, 'commits', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="apiPermUpdate(api.key, 'commits', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioCommits" ng-click="apiPermUpdate(api.key, 'commits', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Releases()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="apiPermUpdate(row.key, 'releases', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="apiPermUpdate(row.key, 'releases', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="apiPermUpdate(api.key, 'releases', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioReleases" ng-click="apiPermUpdate(api.key, 'releases', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -125,15 +129,15 @@
                                 <th>Databases()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="apiPermUpdate(row.key, 'databases', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="apiPermUpdate(row.key, 'databases', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="apiPermUpdate(api.key, 'databases', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDatabases" ng-click="apiPermUpdate(api.key, 'databases', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Tables()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioTables" ng-click="apiPermUpdate(row.key, 'tables', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioTables" ng-click="apiPermUpdate(row.key, 'tables', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioTables" ng-click="apiPermUpdate(api.key, 'tables', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioTables" ng-click="apiPermUpdate(api.key, 'tables', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -141,15 +145,15 @@
                                 <th>Delete()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="apiPermUpdate(row.key, 'delete', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="apiPermUpdate(row.key, 'delete', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="apiPermUpdate(api.key, 'delete', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDelete" ng-click="apiPermUpdate(api.key, 'delete', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Tags()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioTags" ng-click="apiPermUpdate(row.key, 'tags', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioTags" ng-click="apiPermUpdate(row.key, 'tags', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioTags" ng-click="apiPermUpdate(api.key, 'tags', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioTags" ng-click="apiPermUpdate(api.key, 'tags', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -157,15 +161,15 @@
                                 <th>Diff()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="apiPermUpdate(row.key, 'diff', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="apiPermUpdate(row.key, 'diff', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="apiPermUpdate(api.key, 'diff', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDiff" ng-click="apiPermUpdate(api.key, 'diff', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Upload()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="apiPermUpdate(row.key, 'upload', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="apiPermUpdate(row.key, 'upload', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="apiPermUpdate(api.key, 'upload', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioUpload" ng-click="apiPermUpdate(api.key, 'upload', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -173,15 +177,15 @@
                                 <th>Download()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="apiPermUpdate(row.key, 'download', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="apiPermUpdate(row.key, 'download', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="apiPermUpdate(api.key, 'download', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioDownload" ng-click="apiPermUpdate(api.key, 'download', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Views()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioViews" ng-click="apiPermUpdate(row.key, 'views', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioViews" ng-click="apiPermUpdate(row.key, 'views', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioViews" ng-click="apiPermUpdate(api.key, 'views', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioViews" ng-click="apiPermUpdate(api.key, 'views', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -189,15 +193,15 @@
                                 <th>Indexes()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="apiPermUpdate(row.key, 'indexes', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="apiPermUpdate(row.key, 'indexes', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="apiPermUpdate(api.key, 'indexes', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioIndexes" ng-click="apiPermUpdate(api.key, 'indexes', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                                 <th>Webpage()</th>
                                 <td>
                                     <div class="btn-group">
-                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="apiPermUpdate(row.key, 'webpage', 'true')" uib-btn-radio="'true'">Yes</label>
-                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="apiPermUpdate(row.key, 'webpage', 'false')" uib-btn-radio="'false'">No</label>
+                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="apiPermUpdate(api.key, 'webpage', 'true')" uib-btn-radio="'true'">Yes</label>
+                                        <label class="btn btn-default" ng-model="radioWebpage" ng-click="apiPermUpdate(api.key, 'webpage', 'false')" uib-btn-radio="'false'">No</label>
                                     </div>
                                 </td>
                             </tr>
@@ -230,12 +234,16 @@
 </div>
 [[ template "footer" . ]]
 <script>
-    var app = angular.module('DBHub', ['ui.bootstrap', 'ngSanitize']);
+    let app = angular.module('DBHub', ['ui.bootstrap', 'ngSanitize']);
     app.controller('prefView', function($scope, $http, $httpParamSerializerJQLike) {
         // API Keys
         $scope.apiKeys = [[ .APIKeys ]];
 
+        // Database names
+        $scope.dbList = [[ .DBNames ]];
+
         // Set initial permissions to true for the API keys
+        // TODO: These will need updating, depending on what the server sends
         $scope.radioBranches = "true";
         $scope.radioColumns = "true";
         $scope.radioCommits = "true";
@@ -253,11 +261,56 @@
         $scope.radioViews = "true";
         $scope.radioWebpage = "true";
 
-        // Placeholder values
-        // TODO: ...
-        $scope.dbList = ["SomeDatabase", "AnotherDatabase", "MyDatabase"];
-        $scope.selectedDB = "MyDatabase";
+        // TODO: These will depend on what the server sends. eg existing value stored in the backend
+        $scope.allDatabases = true;
+        $scope.selectedDB = "All databases";
 
+        // Send the changed database selection to the server
+        $scope.changeDB = function(apiKey, newDB) {
+console.log("changeDB() called");
+            // Send the new database info to the server
+            $http({
+                method: "POST",
+                url: "/x/apikeydbupdate/",
+                data: $httpParamSerializerJQLike({
+                    "apikey": encodeURIComponent(apiKey),
+                    "dbname": encodeURIComponent(newDB),
+                    "alldbs": encodeURIComponent($scope.allDatabases),
+                }),
+                headers: { "Content-Type": "application/x-www-form-urlencoded" }
+            }).then(function (response) {
+console.log(response.data);
+                // Clear any error message
+                $scope.statusMessageColour = "green";
+                $scope.statusMessage = "";
+            }, function failure(response) {
+console.log(response.data);
+                $scope.statusMessageColour = "red";
+                $scope.statusMessage = "Server message: " + response.data;
+            });
+        }
+
+        // Select "all databases"
+        $scope.allDBs = function(apiKey) {
+            $scope.selectedDB = "All databases";
+            $scope.allDatabases = true;
+console.log("ALL databases set to true");
+
+            // Send the change to the backend
+            $scope.changeDB(apiKey, "");
+        }
+
+        // Change the selected database
+        $scope.selectDB = function(apiKey, newDB) {
+            // TODO: Work with multiple api keys
+            $scope.selectedDB = newDB;
+console.log("Selected database set to: " + newDB);
+            $scope.allDatabases = false;
+console.log("ALL databases set to false");
+
+            // Send the change to the backend
+            $scope.changeDB(apiKey, newDB);
+        }
 
         // If the supplied display name is blank, we set a placeholder value instead
         $scope.FullName = "";
@@ -286,29 +339,22 @@
             lock.show();
         };
 
-        // Call the server to update the api permission
-        $scope.apiPermUpdate = function(apikey, perm, value) {
-            console.log("apikey: " + apikey);
-            console.log("perm: " + perm);
-            console.log("value: " + value);
-
+        // Send the updated permission to the backend
+        $scope.apiPermUpdate = function(apiKey, perm, value) {
             $http({
                 method: "POST",
-                url: "/x/apipermupdate/",
+                url: "/x/apikeypermupdate/",
                 data: $httpParamSerializerJQLike({
-                    "apikey": encodeURIComponent(apikey),
+                    "apikey": encodeURIComponent(apiKey),
                     "perm": encodeURIComponent(perm),
                     "value": encodeURIComponent(value)
                 }),
                 headers: { "Content-Type": "application/x-www-form-urlencoded" }
             }).then(function (response) {
-                console.log(response.data);
-
+                // Clear any error message
                 $scope.statusMessageColour = "green";
-                $scope.statusMessage = "Server message: " + response.data;
+                $scope.statusMessage = "";
             }, function failure(response) {
-                console.log(response.data);
-
                 $scope.statusMessageColour = "red";
                 $scope.statusMessage = "Server message: " + response.data;
             });


### PR DESCRIPTION
This is still very much a work in progress.  The goal is for people to be able to limit what can be done with their API keys. eg, set permissions

So far, the UI pieces are at the bottom of the user Settings page, and look like this:

![2021-06-08-api-keys-concept_layout_v2](https://user-images.githubusercontent.com/406299/121065178-cfb6ef00-c80b-11eb-953c-37c95c068995.png)

While ok for an initial go, it seems like it could become very unwieldy with even just a few API keys.  So, the field of on/off boxes and similar might be better moved into a separate page with a button to go there.  eg <kbd>Change permissions</kbd> or something

List of things:

* [ ] - On/off toggles to select which functions are allowed for a given API key
  * Probably 60-70% done
* [ ] - Database selector, to limit which database(s) are API key is allowed to work on
  * So far, it's "All databases" or "Pick a specific one".  That should be good enough to start with
  * Probably 60-70% done
* [ ] - IP address range(s), to limit which IP addresses the API key is allowed to be requested from
  * Pretty sure this will be a good idea for places who know they'll only be requesting from specific addresses (eg static ip or similar)
  * Not yet started
* [ ] - Hook up the options to the actual API code, to check things
  * Not yet started