### PR TITLE
Use RWMutex instead of Mutex for the job queue

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -99,7 +99,7 @@ func main() {
 
 	// Start background goroutines to handle job queue responses
 	if !com.UseAMQP {
-		com.ResponseWaiters = com.NewResponseReceiver()
+		com.ResponseQueue = com.NewResponseQueue()
 		com.CheckResponsesQueue = make(chan struct{})
 		com.SubmitterInstance = com.RandomString(3)
 		go com.ResponseQueueCheck()

--- a/common/live.go
+++ b/common/live.go
@@ -691,13 +691,13 @@ func RemoveLiveDB(dbOwner, dbName string) (err error) {
 func WaitForResponse[T any](jobID int, resp *T) (err error) {
 	// Add the response receiver
 	responseChan := make(chan ResponseInfo)
-	ResponseWaiters.AddReceiver(jobID, &responseChan)
+	ResponseQueue.AddReceiver(jobID, &responseChan)
 
 	// Wait for a response
 	response := <-responseChan
 
 	// Remove the response receiver
-	ResponseWaiters.RemoveReceiver(jobID)
+	ResponseQueue.RemoveReceiver(jobID)
 
 	// Update the response status to 'processed' (should be fine done async)
 	go ResponseComplete(response.responseID)

--- a/common/live_types.go
+++ b/common/live_types.go
@@ -98,14 +98,14 @@ type ResponseInfo struct {
 
 // ResponseReceivers is a simple structure used for matching up job queue responses to the caller who submitted the job
 type ResponseReceivers struct {
-	sync.Mutex
+	sync.RWMutex
 	receivers map[int]*chan ResponseInfo
 }
 
-// NewResponseReceiver is the constructor function for creating new ResponseReceivers
-func NewResponseReceiver() *ResponseReceivers {
+// NewResponseQueue is the constructor function for creating a new ResponseReceivers
+func NewResponseQueue() *ResponseReceivers {
 	z := ResponseReceivers{
-		Mutex:     sync.Mutex{},
+		RWMutex:   sync.RWMutex{},
 		receivers: nil,
 	}
 	z.receivers = make(map[int]*chan ResponseInfo)

--- a/webui/main.go
+++ b/webui/main.go
@@ -3189,7 +3189,7 @@ func main() {
 
 	// Start background goroutines to handle job queue responses
 	if !com.UseAMQP {
-		com.ResponseWaiters = com.NewResponseReceiver()
+		com.ResponseQueue = com.NewResponseQueue()
 		com.CheckResponsesQueue = make(chan struct{})
 		com.SubmitterInstance = com.RandomString(3)
 		go com.ResponseQueueCheck()


### PR DESCRIPTION
Should be a safe optimisation for the job queue code.  Also renamed a variable for better clarity.