### PR TITLE
Catch termination signals and shut down the daemons nicely

### DIFF
--- a/common/postgresql_live.go
+++ b/common/postgresql_live.go
@@ -545,6 +545,12 @@ func ResponseQueueListen() {
 	}
 
 	// Listen for notify events
+	if JobListenConn == nil {
+		log.Fatalf("%v: ERROR, couldn't start ResponseQueueListen() as JobListenConn IS NILL", Conf.Live.Nodename)
+	}
+	if JobListenConn.IsClosed() {
+		log.Fatalf("%v: ERROR, couldn't start ResponseQueueListen() as connection to job responses listener is NOT open", Conf.Live.Nodename)
+	}
 	_, err := JobListenConn.Exec(context.Background(), "LISTEN job_responses_queue")
 	if err != nil {
 		log.Fatal(err)

--- a/live/main.go
+++ b/live/main.go
@@ -67,6 +67,10 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Start background signal handler
+	exitSignal := make(chan struct{}, 1)
+	go com.SignalHandler(&exitSignal)
+
 	// Make sure the channel to the AMQP server is still open
 	if com.UseAMQP {
 		// Create queue for receiving new database creation requests
@@ -440,12 +444,6 @@ func main() {
 
 	log.Printf("%s: listening for requests", com.Conf.Live.Nodename)
 
-	// Endless loop
-	var forever chan struct{}
-	<-forever
-
-	// Close the channel to the MQ server
-	if com.UseAMQP {
-		_ = com.CloseMQChannel(ch)
-	}
+	// Wait for exit signal
+	<- exitSignal
 }


### PR DESCRIPTION
This should avoid a potential race condition where a daemon shuts down after submitting a job to the live nodes, but before processing the response.