### PR TITLE
database: add missing jsquery extension

### DIFF
--- a/database/dbhub.sql
+++ b/database/dbhub.sql
@@ -1,3 +1,5 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+
 --
 -- PostgreSQL database dump
 --
@@ -15,6 +17,20 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: jsquery; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS jsquery WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION jsquery; Type: COMMENT; Schema: -; Owner:
+--
+
+COMMENT ON EXTENSION jsquery IS 'data type for jsonb inspection';
+
 
 --
 -- Name: permissions; Type: TYPE; Schema: public; Owner: -


### PR DESCRIPTION
This should be in the base schema sql, rather than being added in a migration.

It's on our production systems already, so has somehow been missed in the database schema file.