### PR TITLE
test: add a route to generate a client cert

### DIFF
--- a/common/cypress.go
+++ b/common/cypress.go
@@ -248,16 +248,34 @@ func CreateTag(dbOwner, dbName, tagName, tagDescription, taggerName, taggerEmail
 }
 
 // EnvProd changes the running environment to be "production"
-// NOTE - This route to call this is only available when the server is _started_ in the "test" environment
+// NOTE - The route to call this is only available when the server is started in the "test" environment
 func EnvProd(w http.ResponseWriter, r *http.Request) {
 	config.Conf.Environment.Environment = "production"
 	return
 }
 
 // EnvTest changes the running environment to be "test"
-// NOTE - This route to call this is only available when the server is _started_ in the "test" environment
+// NOTE - The route to call this is only available when the server is started in the "test" environment
 func EnvTest(w http.ResponseWriter, r *http.Request) {
 	config.Conf.Environment.Environment = "test"
+	return
+}
+
+// GenCert generates a client certificate for the current user
+func GenCert(w http.ResponseWriter, r *http.Request) {
+	loggedInUser := config.Conf.Environment.UserOverride
+	newCert, err := GenerateClientCert(loggedInUser)
+	if err != nil {
+		log.Printf("Error generating client certificate for user '%s': %s!", loggedInUser, err)
+		return
+	}
+
+	// Send the client certificate to the user
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s.cert.pem"`, loggedInUser))
+	// Note, don't use "application/x-x509-user-cert", otherwise the browser may try to install it!
+	// Useful reference info: https://pki-tutorial.readthedocs.io/en/latest/mime.html
+	w.Header().Set("Content-Type", "application/x-pem-file")
+	w.Write(newCert)
 	return
 }
 

--- a/webui/main.go
+++ b/webui/main.go
@@ -3421,6 +3421,7 @@ func main() {
 		http.Handle("/x/test/seed", gz.GzipHandler(logReq(com.CypressSeed)))
 		http.Handle("/x/test/envprod", gz.GzipHandler(logReq(com.EnvProd)))
 		http.Handle("/x/test/envtest", gz.GzipHandler(logReq(com.EnvTest)))
+		http.Handle("/x/test/gencert", gz.GzipHandler(logReq(com.GenCert)))
 		http.Handle("/x/test/switchdefault", gz.GzipHandler(logReq(com.SwitchDefault)))
 		http.Handle("/x/test/switchfirst", gz.GzipHandler(logReq(com.SwitchFirst)))
 		http.Handle("/x/test/switchsecond", gz.GzipHandler(logReq(com.SwitchSecond)))


### PR DESCRIPTION
Adds a route (only available during tests) for generating a client certificate.

We need this (or something like it) for automated CI testing of [dio](https://github.com/sqlitebrowser/dio).